### PR TITLE
Fix/port robustness

### DIFF
--- a/lib/omniauth/openid_connect/provider.rb
+++ b/lib/omniauth/openid_connect/provider.rb
@@ -120,7 +120,7 @@ module OmniAuth
       private
 
       def ensure_client_option_types!(opts)
-        opts[:port] = opts[:port].to_i
+        opts[:port] = opts[:port].to_i if opts[:port]
         opts
       end
 

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -188,6 +188,16 @@ describe OmniAuth::OpenIDConnect::Provider do
           expect(options[:userinfo_endpoint]).to eq '/bros'
         end
       end
+
+      context 'with no port being configured' do
+        before do
+          config.delete(:port)
+        end
+
+        it 'defaults the port to nil' do
+          expect(options[:port]).to be_nil
+        end
+      end
     end
 
     describe 'host' do


### PR DESCRIPTION
Defaults the port to 443 if no port is specified. Before, it used to default to 0 which caused errors.
