### PR TITLE
update azure host as the old one is deprecated

### DIFF
--- a/lib/omniauth/openid_connect/azure.rb
+++ b/lib/omniauth/openid_connect/azure.rb
@@ -1,7 +1,7 @@
 module OmniAuth::OpenIDConnect
   class Azure < Provider
     def host
-      config?(:host) || "login.microsoftonline.com"
+      config?(:host) || "b2clogin.com"
     end
 
     def tenant


### PR DESCRIPTION
If I read [this](https://docs.microsoft.com/en-gb/azure/active-directory-b2c/b2clogin) right, we need to change the host as proposed.

I'm not 100% sure on what Azure Active Directory B2C, specifically the B2C is, but it should be relevant for us.